### PR TITLE
Implement dual storage backend with MongoDB/memory toggle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
-# MongoDB Configuration
+# Server
+PORT=3001
+
+# Storage toggle
+# Set to "true" to use MongoDB via Mongoose, or "false" to use in-memory storage
+USE_MONGO=false
+
+# Mongo connection string (used only when USE_MONGO=true)
 MONGODB_URI=mongodb://localhost:27017/dao-management
-
-# Application Configuration
-NODE_ENV=development
-PING_MESSAGE=ping
-
-# Port Configuration
-PORT=3000

--- a/backend-express/models/Dao.ts
+++ b/backend-express/models/Dao.ts
@@ -42,7 +42,7 @@ const DaoSchema = new Schema<Dao>(
   },
 );
 
-// Create and export the model
-const DaoModel = mongoose.model<Dao>("Dao", DaoSchema);
+// Create and export the model (reuse if already compiled to avoid OverwriteModelError in tests)
+const DaoModel = (mongoose.models.Dao as mongoose.Model<Dao>) || mongoose.model<Dao>("Dao", DaoSchema);
 
 export default DaoModel;

--- a/backend-express/models/Dao.ts
+++ b/backend-express/models/Dao.ts
@@ -43,6 +43,8 @@ const DaoSchema = new Schema<Dao>(
 );
 
 // Create and export the model (reuse if already compiled to avoid OverwriteModelError in tests)
-const DaoModel = (mongoose.models.Dao as mongoose.Model<Dao>) || mongoose.model<Dao>("Dao", DaoSchema);
+const DaoModel =
+  (mongoose.models.Dao as mongoose.Model<Dao>) ||
+  mongoose.model<Dao>("Dao", DaoSchema);
 
 export default DaoModel;

--- a/backend-express/repositories/daoRepository.ts
+++ b/backend-express/repositories/daoRepository.ts
@@ -18,7 +18,9 @@ export type DaoQueryOptions = {
 export interface DaoRepository {
   findAll(): Promise<Dao[]>;
   findById(id: string): Promise<Dao | null>;
-  findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }>;
+  findAndPaginate(
+    opts: DaoQueryOptions,
+  ): Promise<{ items: Dao[]; total: number }>;
   findByNumeroYear(year: number | string): Promise<Dao[]>;
   getLastCreated(): Promise<Dao | null>;
   count(): Promise<number>;

--- a/backend-express/repositories/daoRepository.ts
+++ b/backend-express/repositories/daoRepository.ts
@@ -1,0 +1,31 @@
+import type { Dao } from "@shared/dao";
+
+export type DaoQueryOptions = {
+  search?: string;
+  autorite?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  sort?: string;
+  order?: "asc" | "desc";
+  page?: number;
+  pageSize?: number;
+};
+
+/**
+ * Repository abstraction for Dao entity.
+ * Implementations: MemoryDaoRepository and MongoDaoRepository
+ */
+export interface DaoRepository {
+  findAll(): Promise<Dao[]>;
+  findById(id: string): Promise<Dao | null>;
+  findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }>;
+  findByNumeroYear(year: number | string): Promise<Dao[]>;
+  getLastCreated(): Promise<Dao | null>;
+  count(): Promise<number>;
+
+  insert(dao: Dao): Promise<Dao>;
+  insertMany(daos: Dao[]): Promise<void>;
+  update(id: string, updates: Partial<Dao>): Promise<Dao | null>;
+  deleteById(id: string): Promise<boolean>;
+  deleteAll(): Promise<void>;
+}

--- a/backend-express/repositories/memoryDaoRepository.ts
+++ b/backend-express/repositories/memoryDaoRepository.ts
@@ -1,0 +1,115 @@
+import type { Dao } from "@shared/dao";
+import { daoStorage } from "../data/daoStorage";
+import type { DaoRepository, DaoQueryOptions } from "./daoRepository";
+
+export class MemoryDaoRepository implements DaoRepository {
+  async findAll(): Promise<Dao[]> {
+    return daoStorage.getAll().slice();
+  }
+
+  async findById(id: string): Promise<Dao | null> {
+    return daoStorage.findById(id) || null;
+  }
+
+  async getLastCreated(): Promise<Dao | null> {
+    const list = daoStorage.getAll().slice();
+    if (!list.length) return null;
+    list.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    return list[0];
+  }
+
+  async count(): Promise<number> {
+    return daoStorage.size();
+  }
+
+  async findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }> {
+    const {
+      search,
+      autorite,
+      dateFrom,
+      dateTo,
+      sort = "updatedAt",
+      order = "desc",
+      page = 1,
+      pageSize = 20,
+    } = opts || {};
+
+    let list = daoStorage.getAll().slice();
+
+    if (search && search.trim()) {
+      const q = search.toLowerCase().trim();
+      list = list.filter((d) => {
+        return (
+          (d.numeroListe && d.numeroListe.toLowerCase().includes(q)) ||
+          (d.objetDossier && d.objetDossier.toLowerCase().includes(q)) ||
+          (d.reference && d.reference.toLowerCase().includes(q)) ||
+          (d.autoriteContractante && d.autoriteContractante.toLowerCase().includes(q))
+        );
+      });
+    }
+
+    if (autorite && autorite.trim()) {
+      const a = autorite.trim();
+      list = list.filter((d) => d.autoriteContractante === a);
+    }
+
+    if (dateFrom || dateTo) {
+      let fromTs = dateFrom ? Date.parse(dateFrom) : -Infinity;
+      let toTs = dateTo ? Date.parse(dateTo) : Infinity;
+      if (isNaN(fromTs)) fromTs = -Infinity;
+      if (isNaN(toTs)) toTs = Infinity;
+      list = list.filter((d) => {
+        const t = d.dateDepot ? Date.parse(d.dateDepot) : NaN;
+        if (isNaN(t)) return false;
+        return t >= fromTs && t <= toTs;
+      });
+    }
+
+    const direction = order === "asc" ? 1 : -1;
+    list.sort((a: any, b: any) => {
+      const av = (a as any)[sort] || "";
+      const bv = (b as any)[sort] || "";
+      if (typeof av === "string" && typeof bv === "string") return direction * av.localeCompare(bv);
+      if (av < bv) return -1 * direction;
+      if (av > bv) return 1 * direction;
+      return 0;
+    });
+
+    const total = list.length;
+    const start = (Math.max(1, page) - 1) * pageSize;
+    const items = list.slice(start, start + pageSize);
+
+    return { items, total };
+  }
+
+  async findByNumeroYear(year: number | string): Promise<Dao[]> {
+    const prefix = `DAO-${String(year)}-`;
+    return daoStorage.getAll().filter((d) => d.numeroListe.startsWith(prefix));
+  }
+
+  async insert(dao: Dao): Promise<Dao> {
+    daoStorage.add(dao);
+    return dao;
+  }
+
+  async insertMany(daos: Dao[]): Promise<void> {
+    for (const d of daos) daoStorage.add(d);
+  }
+
+  async update(id: string, updates: Partial<Dao>): Promise<Dao | null> {
+    const idx = daoStorage.findIndexById(id);
+    if (idx === -1) return null;
+    const existing = daoStorage.findById(id)!;
+    const updated: Dao = { ...existing, ...updates } as Dao;
+    daoStorage.updateAtIndex(idx, updated);
+    return updated;
+  }
+
+  async deleteById(id: string): Promise<boolean> {
+    return daoStorage.deleteById(id);
+  }
+
+  async deleteAll(): Promise<void> {
+    daoStorage.clearAll(false);
+  }
+}

--- a/backend-express/repositories/memoryDaoRepository.ts
+++ b/backend-express/repositories/memoryDaoRepository.ts
@@ -22,7 +22,9 @@ export class MemoryDaoRepository implements DaoRepository {
     return daoStorage.size();
   }
 
-  async findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }> {
+  async findAndPaginate(
+    opts: DaoQueryOptions,
+  ): Promise<{ items: Dao[]; total: number }> {
     const {
       search,
       autorite,
@@ -43,7 +45,8 @@ export class MemoryDaoRepository implements DaoRepository {
           (d.numeroListe && d.numeroListe.toLowerCase().includes(q)) ||
           (d.objetDossier && d.objetDossier.toLowerCase().includes(q)) ||
           (d.reference && d.reference.toLowerCase().includes(q)) ||
-          (d.autoriteContractante && d.autoriteContractante.toLowerCase().includes(q))
+          (d.autoriteContractante &&
+            d.autoriteContractante.toLowerCase().includes(q))
         );
       });
     }
@@ -69,7 +72,8 @@ export class MemoryDaoRepository implements DaoRepository {
     list.sort((a: any, b: any) => {
       const av = (a as any)[sort] || "";
       const bv = (b as any)[sort] || "";
-      if (typeof av === "string" && typeof bv === "string") return direction * av.localeCompare(bv);
+      if (typeof av === "string" && typeof bv === "string")
+        return direction * av.localeCompare(bv);
       if (av < bv) return -1 * direction;
       if (av > bv) return 1 * direction;
       return 0;

--- a/backend-express/repositories/mongoDaoRepository.ts
+++ b/backend-express/repositories/mongoDaoRepository.ts
@@ -11,7 +11,7 @@ export class MongoDaoRepository implements DaoRepository {
   async findById(id: string): Promise<Dao | null> {
     const doc = await DaoModel.findOne({ id });
     return doc ? (doc.toObject() as Dao) : null;
-    }
+  }
 
   async getLastCreated(): Promise<Dao | null> {
     const doc = await DaoModel.findOne().sort({ createdAt: -1 });
@@ -22,7 +22,9 @@ export class MongoDaoRepository implements DaoRepository {
     return DaoModel.countDocuments();
   }
 
-  async findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }> {
+  async findAndPaginate(
+    opts: DaoQueryOptions,
+  ): Promise<{ items: Dao[]; total: number }> {
     const {
       search,
       autorite,
@@ -70,12 +72,17 @@ export class MongoDaoRepository implements DaoRepository {
     sortObj[sort] = order === "asc" ? 1 : -1;
 
     const skip = Math.max(0, (Math.max(1, page) - 1) * pageSize);
-    const docs = await DaoModel.find(query).sort(sortObj).skip(skip).limit(pageSize);
+    const docs = await DaoModel.find(query)
+      .sort(sortObj)
+      .skip(skip)
+      .limit(pageSize);
     return { items: docs.map((d) => d.toObject() as Dao), total };
   }
 
   async findByNumeroYear(year: number | string): Promise<Dao[]> {
-    const docs = await DaoModel.find({ numeroListe: { $regex: `^DAO-${year}-` } });
+    const docs = await DaoModel.find({
+      numeroListe: { $regex: `^DAO-${year}-` },
+    });
     return docs.map((d) => d.toObject() as Dao);
   }
 

--- a/backend-express/repositories/mongoDaoRepository.ts
+++ b/backend-express/repositories/mongoDaoRepository.ts
@@ -1,0 +1,110 @@
+import type { Dao } from "@shared/dao";
+import DaoModel from "../models/Dao";
+import type { DaoRepository, DaoQueryOptions } from "./daoRepository";
+
+export class MongoDaoRepository implements DaoRepository {
+  async findAll(): Promise<Dao[]> {
+    const docs = await DaoModel.find().sort({ updatedAt: -1 });
+    return docs.map((d) => d.toObject() as Dao);
+  }
+
+  async findById(id: string): Promise<Dao | null> {
+    const doc = await DaoModel.findOne({ id });
+    return doc ? (doc.toObject() as Dao) : null;
+    }
+
+  async getLastCreated(): Promise<Dao | null> {
+    const doc = await DaoModel.findOne().sort({ createdAt: -1 });
+    return doc ? (doc.toObject() as Dao) : null;
+  }
+
+  async count(): Promise<number> {
+    return DaoModel.countDocuments();
+  }
+
+  async findAndPaginate(opts: DaoQueryOptions): Promise<{ items: Dao[]; total: number }> {
+    const {
+      search,
+      autorite,
+      dateFrom,
+      dateTo,
+      sort = "updatedAt",
+      order = "desc",
+      page = 1,
+      pageSize = 20,
+    } = opts || {};
+
+    const query: any = {};
+    if (search && search.trim()) {
+      const q = search.trim();
+      const regex = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
+      query.$or = [
+        { numeroListe: regex },
+        { objetDossier: regex },
+        { reference: regex },
+        { autoriteContractante: regex },
+      ];
+    }
+    if (autorite && autorite.trim()) {
+      query.autoriteContractante = autorite.trim();
+    }
+
+    if (dateFrom || dateTo) {
+      const range: any = {};
+      if (dateFrom) {
+        const from = new Date(dateFrom);
+        if (!isNaN(from.getTime())) range.$gte = from.toISOString();
+      }
+      if (dateTo) {
+        const to = new Date(dateTo);
+        if (!isNaN(to.getTime())) {
+          to.setHours(23, 59, 59, 999);
+          range.$lte = to.toISOString();
+        }
+      }
+      if (Object.keys(range).length) query.dateDepot = range;
+    }
+
+    const total = await DaoModel.countDocuments(query);
+    const sortObj: any = {};
+    sortObj[sort] = order === "asc" ? 1 : -1;
+
+    const skip = Math.max(0, (Math.max(1, page) - 1) * pageSize);
+    const docs = await DaoModel.find(query).sort(sortObj).skip(skip).limit(pageSize);
+    return { items: docs.map((d) => d.toObject() as Dao), total };
+  }
+
+  async findByNumeroYear(year: number | string): Promise<Dao[]> {
+    const docs = await DaoModel.find({ numeroListe: { $regex: `^DAO-${year}-` } });
+    return docs.map((d) => d.toObject() as Dao);
+  }
+
+  async insert(dao: Dao): Promise<Dao> {
+    const doc = new DaoModel(dao);
+    const saved = await doc.save();
+    return saved.toObject() as Dao;
+  }
+
+  async insertMany(daos: Dao[]): Promise<void> {
+    if (!daos.length) return;
+    await DaoModel.insertMany(daos);
+  }
+
+  async update(id: string, updates: Partial<Dao>): Promise<Dao | null> {
+    const updated = await DaoModel.findOneAndUpdate(
+      { id },
+      { ...updates },
+      { new: true },
+    );
+    return updated ? (updated.toObject() as Dao) : null;
+  }
+
+  async deleteById(id: string): Promise<boolean> {
+    const result = await DaoModel.deleteOne({ id });
+    return result.deletedCount ? result.deletedCount > 0 : false;
+  }
+
+  async deleteAll(): Promise<void> {
+    await DaoModel.deleteMany({});
+  }
+}

--- a/backend-express/server.ts
+++ b/backend-express/server.ts
@@ -3,7 +3,7 @@ import { createServer } from "./index.js";
 import { logger } from "./utils/logger.js";
 
 const app = createServer();
-const PORT = process.env.PORT || 3001;
+const PORT = Number(process.env.BACKEND_PORT || 3001);
 
 app.listen(PORT, () => {
   logger.info(`🚀 Secure backend server running on port ${PORT}`, "SERVER");

--- a/backend-express/services/authService.ts
+++ b/backend-express/services/authService.ts
@@ -561,163 +561,279 @@ export class AuthService {
     role: UserRole;
     password?: string;
   }): Promise<User> {
-    await connectToDatabase();
+    try {
+      await connectToDatabase();
 
-    const normalizedName = normalizeName(userData.name);
+      const normalizedName = normalizeName(userData.name);
 
-    const sameName = await UserModel.findOne({
-      isActive: true,
-      name: new RegExp(`^${normalizedName}$`, "i"),
-    }).exec();
-    if (sameName) {
-      throw new Error("User name already taken");
+      const sameName = await UserModel.findOne({
+        isActive: true,
+        name: new RegExp(`^${normalizedName}$`, "i"),
+      }).exec();
+      if (sameName) {
+        throw new Error("User name already taken");
+      }
+
+      const existingUser = await UserModel.findOne({
+        email: userData.email.toLowerCase(),
+      }).exec();
+      if (existingUser) {
+        throw new Error("User already exists");
+      }
+
+      const defaultPassword = userData.password || "changeme123";
+      const passwordHash = await bcrypt.hash(defaultPassword, 12);
+
+      const doc = await UserModel.create({
+        id: new mongoose.Types.ObjectId().toHexString(),
+        name: normalizedName,
+        email: userData.email.toLowerCase(),
+        role: userData.role,
+        createdAt: new Date().toISOString(),
+        isActive: true,
+        passwordHash,
+        isSuperAdmin: userData.role === "admin",
+      });
+
+      devLog.info(`👤 New user created: ${doc.email} Role: ${doc.role}`);
+      if (doc.role === "admin") await refreshSuperAdminCache();
+      return {
+        id: doc.id,
+        name: doc.name,
+        email: doc.email,
+        role: doc.role,
+        createdAt: doc.createdAt,
+        isActive: doc.isActive,
+        lastLogin: doc.lastLogin,
+        isSuperAdmin: doc.isSuperAdmin,
+      };
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const normalizedName = normalizeName(userData.name);
+      if (fallbackUsers.some((u) => u.email === userData.email.toLowerCase())) {
+        throw new Error("User already exists");
+      }
+      if (fallbackUsers.some((u) => u.name.toLowerCase() === normalizedName.toLowerCase() && u.isActive)) {
+        throw new Error("User name already taken");
+      }
+      const defaultPassword = userData.password || "changeme123";
+      const passwordHash = await bcrypt.hash(defaultPassword, 12);
+      const id = new mongoose.Types.ObjectId().toHexString();
+      const now = new Date().toISOString();
+      fallbackUsers.push({
+        id,
+        name: normalizedName,
+        email: userData.email.toLowerCase(),
+        role: userData.role,
+        passwordHash,
+        createdAt: now,
+        isActive: true,
+        isSuperAdmin: userData.role === "admin",
+      });
+      devLog.info(`👤 [DEV] New in-memory user created: ${userData.email}`);
+      if (userData.role === "admin") superAdminIdCache = id;
+      return {
+        id,
+        name: normalizedName,
+        email: userData.email.toLowerCase(),
+        role: userData.role,
+        createdAt: now,
+        isActive: true,
+        isSuperAdmin: userData.role === "admin",
+      } as User;
     }
-
-    const existingUser = await UserModel.findOne({
-      email: userData.email.toLowerCase(),
-    }).exec();
-    if (existingUser) {
-      throw new Error("User already exists");
-    }
-
-    const defaultPassword = userData.password || "changeme123";
-    const passwordHash = await bcrypt.hash(defaultPassword, 12);
-
-    const doc = await UserModel.create({
-      id: new mongoose.Types.ObjectId().toHexString(),
-      name: normalizedName,
-      email: userData.email.toLowerCase(),
-      role: userData.role,
-      createdAt: new Date().toISOString(),
-      isActive: true,
-      passwordHash,
-      isSuperAdmin: userData.role === "admin",
-    });
-
-    devLog.info(`👤 New user created: ${doc.email} Role: ${doc.role}`);
-    if (doc.role === "admin") await refreshSuperAdminCache();
-    return {
-      id: doc.id,
-      name: doc.name,
-      email: doc.email,
-      role: doc.role,
-      createdAt: doc.createdAt,
-      isActive: doc.isActive,
-      lastLogin: doc.lastLogin,
-      isSuperAdmin: doc.isSuperAdmin,
-    };
   }
 
   static async updateUserRole(
     id: string,
     role: UserRole,
   ): Promise<User | null> {
-    await connectToDatabase();
-    const doc = await UserModel.findOneAndUpdate(
-      { id },
-      { $set: { role } },
-      { new: true },
-    ).exec();
-    if (!doc) return null;
-    devLog.info(`🔄 User role updated: ${doc.email} → ${role}`);
-    return {
-      id: doc.id,
-      name: doc.name,
-      email: doc.email,
-      role: doc.role,
-      createdAt: doc.createdAt,
-      lastLogin: doc.lastLogin,
-      isActive: doc.isActive,
-      isSuperAdmin: doc.isSuperAdmin,
-    };
+    try {
+      await connectToDatabase();
+      const doc = await UserModel.findOneAndUpdate(
+        { id },
+        { $set: { role } },
+        { new: true },
+      ).exec();
+      if (!doc) return null;
+      devLog.info(`🔄 User role updated: ${doc.email} → ${role}`);
+      return {
+        id: doc.id,
+        name: doc.name,
+        email: doc.email,
+        role: doc.role,
+        createdAt: doc.createdAt,
+        lastLogin: doc.lastLogin,
+        isActive: doc.isActive,
+        isSuperAdmin: doc.isSuperAdmin,
+      };
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.id === id && x.isActive);
+      if (!u) return null;
+      u.role = role;
+      if (role === "admin") u.isSuperAdmin = true;
+      devLog.info(`🔄 [DEV] In-memory user role updated: ${u.email} → ${role}`);
+      return {
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        lastLogin: u.lastLogin,
+        isActive: u.isActive,
+        isSuperAdmin: Boolean(u.isSuperAdmin),
+      } as User;
+    }
   }
 
   static async deactivateUser(id: string): Promise<boolean> {
-    await connectToDatabase();
-    const doc = await UserModel.findOneAndUpdate(
-      { id },
-      { $set: { isActive: false } },
-      { new: true },
-    ).exec();
-    if (!doc) return false;
+    try {
+      await connectToDatabase();
+      const doc = await UserModel.findOneAndUpdate(
+        { id },
+        { $set: { isActive: false } },
+        { new: true },
+      ).exec();
+      if (!doc) return false;
 
-    for (const token of Array.from(activeSessions)) {
-      try {
-        const decoded = jwt.verify(token, JWT_SECRET as string) as AuthUser;
-        if (decoded.id === id) activeSessions.delete(token);
-      } catch {}
+      for (const token of Array.from(activeSessions)) {
+        try {
+          const decoded = jwt.verify(token, JWT_SECRET as string) as AuthUser;
+          if (decoded.id === id) activeSessions.delete(token);
+        } catch {}
+      }
+
+      devLog.info(`🚫 User deactivated: ${doc.email}`);
+      return true;
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.id === id && x.isActive);
+      if (!u) return false;
+      u.isActive = false;
+      for (const token of Array.from(activeSessions)) {
+        try {
+          const decoded = jwt.verify(token, JWT_SECRET as string) as AuthUser;
+          if (decoded.id === id) activeSessions.delete(token);
+        } catch {}
+      }
+      devLog.info(`🚫 [DEV] In-memory user deactivated: ${u.email}`);
+      return true;
     }
-
-    devLog.info(`🚫 User deactivated: ${doc.email}`);
-    return true;
   }
 
   static async changePassword(
     id: string,
     newPassword: string,
   ): Promise<boolean> {
-    await connectToDatabase();
-    const doc = await UserModel.findOne({ id, isActive: true }).exec();
-    if (!doc) return false;
-    doc.passwordHash = await bcrypt.hash(newPassword, 12);
-    await doc.save();
-    devLog.info(`🔑 Password changed for: ${doc.email}`);
-    return true;
+    try {
+      await connectToDatabase();
+      const doc = await UserModel.findOne({ id, isActive: true }).exec();
+      if (!doc) return false;
+      doc.passwordHash = await bcrypt.hash(newPassword, 12);
+      await doc.save();
+      devLog.info(`🔑 Password changed for: ${doc.email}`);
+      return true;
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.id === id && x.isActive);
+      if (!u) return false;
+      u.passwordHash = await bcrypt.hash(newPassword, 12);
+      devLog.info(`🔑 [DEV] Password changed for: ${u.email}`);
+      return true;
+    }
   }
 
   static async updateProfile(
     id: string,
     updates: { name: string; email?: string },
   ): Promise<User | null> {
-    await connectToDatabase();
-    const doc = await UserModel.findOne({ id, isActive: true }).exec();
-    if (!doc) return null;
+    try {
+      await connectToDatabase();
+      const doc = await UserModel.findOne({ id, isActive: true }).exec();
+      if (!doc) return null;
 
-    if (
-      updates.email &&
-      updates.email.toLowerCase() !== doc.email.toLowerCase()
-    ) {
-      throw new Error("Email change not allowed");
+      if (
+        updates.email &&
+        updates.email.toLowerCase() !== doc.email.toLowerCase()
+      ) {
+        throw new Error("Email change not allowed");
+      }
+
+      const normalizedName = normalizeName(updates.name);
+      const conflict = await UserModel.findOne({
+        isActive: true,
+        id: { $ne: id },
+        name: new RegExp(`^${normalizedName}$`, "i"),
+      }).exec();
+      if (conflict) throw new Error("User name already taken");
+
+      doc.name = normalizedName;
+      await doc.save();
+
+      devLog.info(`📝 Profile updated for: ${doc.email}`);
+      return {
+        id: doc.id,
+        name: doc.name,
+        email: doc.email,
+        role: doc.role,
+        createdAt: doc.createdAt,
+        lastLogin: doc.lastLogin,
+        isActive: doc.isActive,
+        isSuperAdmin: doc.isSuperAdmin,
+      };
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.id === id && x.isActive);
+      if (!u) return null;
+      const normalizedName = normalizeName(updates.name);
+      if (fallbackUsers.some((x) => x.isActive && x.id !== id && x.name.toLowerCase() === normalizedName.toLowerCase())) {
+        throw new Error("User name already taken");
+      }
+      if (updates.email && updates.email.toLowerCase() !== u.email.toLowerCase()) {
+        throw new Error("Email change not allowed");
+      }
+      u.name = normalizedName;
+      devLog.info(`📝 [DEV] Profile updated for: ${u.email}`);
+      return {
+        id: u.id,
+        name: u.name,
+        email: u.email,
+        role: u.role,
+        createdAt: u.createdAt,
+        lastLogin: u.lastLogin,
+        isActive: u.isActive,
+        isSuperAdmin: Boolean(u.isSuperAdmin),
+      } as User;
     }
-
-    const normalizedName = normalizeName(updates.name);
-    const conflict = await UserModel.findOne({
-      isActive: true,
-      id: { $ne: id },
-      name: new RegExp(`^${normalizedName}$`, "i"),
-    }).exec();
-    if (conflict) throw new Error("User name already taken");
-
-    doc.name = normalizedName;
-    await doc.save();
-
-    devLog.info(`📝 Profile updated for: ${doc.email}`);
-    return {
-      id: doc.id,
-      name: doc.name,
-      email: doc.email,
-      role: doc.role,
-      createdAt: doc.createdAt,
-      lastLogin: doc.lastLogin,
-      isActive: doc.isActive,
-      isSuperAdmin: doc.isSuperAdmin,
-    };
   }
 
   static async generateResetToken(email: string): Promise<string | null> {
-    await connectToDatabase();
-    const user = await UserModel.findOne({
-      email: email.toLowerCase(),
-      isActive: true,
-    }).exec();
-    if (!user) return null;
+    try {
+      await connectToDatabase();
+      const user = await UserModel.findOne({
+        email: email.toLowerCase(),
+        isActive: true,
+      }).exec();
+      if (!user) return null;
 
-    const crypto = require("crypto");
-    const token = crypto.randomBytes(32).toString("hex");
-    const expires = new Date(Date.now() + 15 * 60 * 1000);
-    resetTokens[token] = { email: user.email, expires };
-    devLog.info(`🔒 Password reset token generated for: ${user.email}`);
-    return token;
+      const crypto = require("crypto");
+      const token = crypto.randomBytes(32).toString("hex");
+      const expires = new Date(Date.now() + 15 * 60 * 1000);
+      resetTokens[token] = { email: user.email, expires };
+      devLog.info(`🔒 Password reset token generated for: ${user.email}`);
+      return token;
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+      if (!u) return null;
+      const crypto = require("crypto");
+      const token = crypto.randomBytes(32).toString("hex");
+      const expires = new Date(Date.now() + 15 * 60 * 1000);
+      resetTokens[token] = { email: u.email, expires };
+      devLog.info(`🔒 [DEV] Password reset token generated for: ${u.email}`);
+      return token;
+    }
   }
 
   static async verifyResetToken(
@@ -742,19 +858,29 @@ export class AuthService {
     const isValid = await this.verifyResetToken(token, email);
     if (!isValid) return false;
 
-    await connectToDatabase();
-    const user = await UserModel.findOne({
-      email: email.toLowerCase(),
-      isActive: true,
-    }).exec();
-    if (!user) return false;
+    try {
+      await connectToDatabase();
+      const user = await UserModel.findOne({
+        email: email.toLowerCase(),
+        isActive: true,
+      }).exec();
+      if (!user) return false;
 
-    user.passwordHash = await bcrypt.hash(newPassword, 12);
-    await user.save();
+      user.passwordHash = await bcrypt.hash(newPassword, 12);
+      await user.save();
 
-    delete resetTokens[token];
-    devLog.info(`🔑 Password reset successful for: ${user.email}`);
-    return true;
+      delete resetTokens[token];
+      devLog.info(`🔑 Password reset successful for: ${user.email}`);
+      return true;
+    } catch (e) {
+      if (!DEV_FALLBACK_ENABLED) throw e;
+      const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+      if (!u) return false;
+      u.passwordHash = await bcrypt.hash(newPassword, 12);
+      delete resetTokens[token];
+      devLog.info(`🔑 [DEV] Password reset successful for: ${u.email}`);
+      return true;
+    }
   }
 
   static getActiveSessionCount(): number {

--- a/backend-express/services/authService.ts
+++ b/backend-express/services/authService.ts
@@ -14,8 +14,8 @@ import UserModel, { type UserDocument } from "../models/User";
 
 const JWT_SECRET = process.env.JWT_SECRET;
 const DEV_FALLBACK_ENABLED =
-  ((process.env.ALLOW_DEV_AUTH_FALLBACK || "true").toLowerCase() ===
-    "true" && process.env.NODE_ENV !== "production");
+  (process.env.ALLOW_DEV_AUTH_FALLBACK || "true").toLowerCase() === "true" &&
+  process.env.NODE_ENV !== "production";
 
 // In-memory fallback users for development when MongoDB is unavailable
 const fallbackUsers: Array<{
@@ -35,9 +35,24 @@ function seedFallbackUsers() {
   if (fallbackUsers.length > 0) return;
   const now = new Date().toISOString();
   const demo = [
-    { name: "Admin User", email: "admin@2snd.fr", role: "admin" as UserRole, password: "admin123" },
-    { name: "Marie Dubois", email: "marie.dubois@2snd.fr", role: "user" as UserRole, password: "marie123" },
-    { name: "Pierre Martin", email: "pierre.martin@2snd.fr", role: "user" as UserRole, password: "pierre123" },
+    {
+      name: "Admin User",
+      email: "admin@2snd.fr",
+      role: "admin" as UserRole,
+      password: "admin123",
+    },
+    {
+      name: "Marie Dubois",
+      email: "marie.dubois@2snd.fr",
+      role: "user" as UserRole,
+      password: "marie123",
+    },
+    {
+      name: "Pierre Martin",
+      email: "pierre.martin@2snd.fr",
+      role: "user" as UserRole,
+      password: "pierre123",
+    },
   ];
   for (const u of demo) {
     const id = new mongoose.Types.ObjectId().toHexString();
@@ -326,7 +341,9 @@ export class AuthService {
         return decoded;
       } catch (dbErr) {
         if (DEV_FALLBACK_ENABLED) {
-          const u = fallbackUsers.find((x) => x.id === decoded.id && x.isActive);
+          const u = fallbackUsers.find(
+            (x) => x.id === decoded.id && x.isActive,
+          );
           if (u) {
             if (!activeSessions.has(token)) activeSessions.add(token);
             authLog.tokenVerification(u.email, true);
@@ -421,16 +438,19 @@ export class AuthService {
       if (DEV_FALLBACK_ENABLED) {
         return fallbackUsers
           .filter((u) => u.isActive)
-          .map((u) => ({
-            id: u.id,
-            name: u.name,
-            email: u.email,
-            role: u.role,
-            createdAt: u.createdAt,
-            lastLogin: u.lastLogin,
-            isActive: u.isActive,
-            isSuperAdmin: Boolean(u.isSuperAdmin),
-          } as User));
+          .map(
+            (u) =>
+              ({
+                id: u.id,
+                name: u.name,
+                email: u.email,
+                role: u.role,
+                createdAt: u.createdAt,
+                lastLogin: u.lastLogin,
+                isActive: u.isActive,
+                isSuperAdmin: Boolean(u.isSuperAdmin),
+              }) as User,
+          );
       }
       throw _;
     }
@@ -528,9 +548,15 @@ export class AuthService {
       return await bcrypt.compare(password, user.passwordHash);
     } catch (_) {
       if (DEV_FALLBACK_ENABLED) {
-        const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+        const u = fallbackUsers.find(
+          (x) => x.email === email.toLowerCase() && x.isActive,
+        );
         if (!u) return false;
-        try { return await bcrypt.compare(password, u.passwordHash); } catch { return false; }
+        try {
+          return await bcrypt.compare(password, u.passwordHash);
+        } catch {
+          return false;
+        }
       }
       return false;
     }
@@ -549,7 +575,11 @@ export class AuthService {
       if (DEV_FALLBACK_ENABLED) {
         const u = fallbackUsers.find((x) => x.id === id && x.isActive);
         if (!u) return false;
-        try { return await bcrypt.compare(password, u.passwordHash); } catch { return false; }
+        try {
+          return await bcrypt.compare(password, u.passwordHash);
+        } catch {
+          return false;
+        }
       }
       return false;
     }
@@ -613,7 +643,12 @@ export class AuthService {
       if (fallbackUsers.some((u) => u.email === userData.email.toLowerCase())) {
         throw new Error("User already exists");
       }
-      if (fallbackUsers.some((u) => u.name.toLowerCase() === normalizedName.toLowerCase() && u.isActive)) {
+      if (
+        fallbackUsers.some(
+          (u) =>
+            u.name.toLowerCase() === normalizedName.toLowerCase() && u.isActive,
+        )
+      ) {
         throw new Error("User name already taken");
       }
       const defaultPassword = userData.password || "changeme123";
@@ -787,10 +822,20 @@ export class AuthService {
       const u = fallbackUsers.find((x) => x.id === id && x.isActive);
       if (!u) return null;
       const normalizedName = normalizeName(updates.name);
-      if (fallbackUsers.some((x) => x.isActive && x.id !== id && x.name.toLowerCase() === normalizedName.toLowerCase())) {
+      if (
+        fallbackUsers.some(
+          (x) =>
+            x.isActive &&
+            x.id !== id &&
+            x.name.toLowerCase() === normalizedName.toLowerCase(),
+        )
+      ) {
         throw new Error("User name already taken");
       }
-      if (updates.email && updates.email.toLowerCase() !== u.email.toLowerCase()) {
+      if (
+        updates.email &&
+        updates.email.toLowerCase() !== u.email.toLowerCase()
+      ) {
         throw new Error("Email change not allowed");
       }
       u.name = normalizedName;
@@ -825,7 +870,9 @@ export class AuthService {
       return token;
     } catch (e) {
       if (!DEV_FALLBACK_ENABLED) throw e;
-      const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+      const u = fallbackUsers.find(
+        (x) => x.email === email.toLowerCase() && x.isActive,
+      );
       if (!u) return null;
       const crypto = require("crypto");
       const token = crypto.randomBytes(32).toString("hex");
@@ -874,7 +921,9 @@ export class AuthService {
       return true;
     } catch (e) {
       if (!DEV_FALLBACK_ENABLED) throw e;
-      const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+      const u = fallbackUsers.find(
+        (x) => x.email === email.toLowerCase() && x.isActive,
+      );
       if (!u) return false;
       u.passwordHash = await bcrypt.hash(newPassword, 12);
       delete resetTokens[token];

--- a/backend-express/services/authService.ts
+++ b/backend-express/services/authService.ts
@@ -106,10 +106,20 @@ function normalizeName(name: string): string {
 }
 
 async function ensureInitialUsers() {
-  await connectToDatabase().catch((e) => {
+  try {
+    await connectToDatabase();
+  } catch (e) {
     devLog.error("MongoDB indisponible pour l'authentification", e);
+    if (DEV_FALLBACK_ENABLED) {
+      const admin = fallbackUsers.find((u) => u.isSuperAdmin);
+      if (admin) {
+        superAdminIdCache = admin.id;
+        devLog.info("🔐 Dev auth fallback active with in-memory admin user");
+        return;
+      }
+    }
     throw e;
-  });
+  }
 
   const shouldSeed =
     process.env.SEED_USERS === "1" || process.env.SEED_USERS === "true";
@@ -492,22 +502,32 @@ export class AuthService {
   }
 
   static isSuperAdmin(userId: string): boolean {
-    return Boolean(superAdminIdCache && superAdminIdCache === userId);
+    if (superAdminIdCache && superAdminIdCache === userId) return true;
+    if (DEV_FALLBACK_ENABLED) {
+      const u = fallbackUsers.find((x) => x.id === userId && x.isActive);
+      return Boolean(u?.isSuperAdmin);
+    }
+    return false;
   }
 
   static async verifyPasswordByEmail(
     email: string,
     password: string,
   ): Promise<boolean> {
-    await connectToDatabase();
-    const user = await UserModel.findOne({
-      email: email.toLowerCase(),
-      isActive: true,
-    }).exec();
-    if (!user) return false;
     try {
+      await connectToDatabase();
+      const user = await UserModel.findOne({
+        email: email.toLowerCase(),
+        isActive: true,
+      }).exec();
+      if (!user) return false;
       return await bcrypt.compare(password, user.passwordHash);
-    } catch {
+    } catch (_) {
+      if (DEV_FALLBACK_ENABLED) {
+        const u = fallbackUsers.find((x) => x.email === email.toLowerCase() && x.isActive);
+        if (!u) return false;
+        try { return await bcrypt.compare(password, u.passwordHash); } catch { return false; }
+      }
       return false;
     }
   }
@@ -516,12 +536,17 @@ export class AuthService {
     id: string,
     password: string,
   ): Promise<boolean> {
-    await connectToDatabase();
-    const user = await UserModel.findOne({ id, isActive: true }).exec();
-    if (!user) return false;
     try {
+      await connectToDatabase();
+      const user = await UserModel.findOne({ id, isActive: true }).exec();
+      if (!user) return false;
       return await bcrypt.compare(password, user.passwordHash);
-    } catch {
+    } catch (_) {
+      if (DEV_FALLBACK_ENABLED) {
+        const u = fallbackUsers.find((x) => x.id === id && x.isActive);
+        if (!u) return false;
+        try { return await bcrypt.compare(password, u.passwordHash); } catch { return false; }
+      }
       return false;
     }
   }

--- a/backend-express/services/authService.ts
+++ b/backend-express/services/authService.ts
@@ -332,6 +332,10 @@ export class AuthService {
             authLog.tokenVerification(u.email, true);
             return decoded;
           }
+          // Accept decoded token in dev when DB is unavailable (graceful mode)
+          if (!activeSessions.has(token)) activeSessions.add(token);
+          authLog.tokenVerification(decoded.email || decoded.id, true);
+          return decoded;
         }
         activeSessions.delete(token);
         return null;

--- a/backend-express/services/daoService.ts
+++ b/backend-express/services/daoService.ts
@@ -1,251 +1,89 @@
-import DaoModel from "../models/Dao";
-import { connectToDatabase } from "../config/database";
-import { daoStorage } from "../data/daoStorage";
 import type { Dao } from "@shared/dao";
+import { connectToDatabase } from "../config/database";
+import { MemoryDaoRepository } from "../repositories/memoryDaoRepository";
+import { MongoDaoRepository } from "../repositories/mongoDaoRepository";
+import type { DaoRepository } from "../repositories/daoRepository";
 
-let useInMemory = false;
-let connectionAttempted = false;
+const WANT_MONGO = (process.env.USE_MONGO || "").toLowerCase() === "true";
+
 // Monotonic per-year sequence tracker to avoid reusing numbers after deletions
 const lastIssuedSeqByYear: Record<string, number> = {};
 
-async function tryConnect(): Promise<boolean> {
-  if (connectionAttempted) return !useInMemory;
-  connectionAttempted = true;
+let repo: DaoRepository | null = null;
+let attempted = false;
+
+async function getRepo(): Promise<DaoRepository> {
+  if (repo) return repo;
+  if (attempted) return repo || new MemoryDaoRepository();
+  attempted = true;
+
+  if (!WANT_MONGO) {
+    repo = new MemoryDaoRepository();
+    return repo;
+  }
+
   try {
     await connectToDatabase();
-    useInMemory = false;
-    return true;
+    repo = new MongoDaoRepository();
+    return repo;
   } catch (e) {
-    console.warn("⚠️ MongoDB not available, falling back to in-memory storage");
-    useInMemory = true;
-    return false;
+    console.warn("⚠️ USE_MONGO=true but MongoDB not available, falling back to in-memory repository:", String(e));
+    repo = new MemoryDaoRepository();
+    return repo;
   }
 }
 
 export class DaoService {
-  private static async ensureConnection() {
-    await tryConnect();
-  }
-
   // Get all DAOs
   static async getAllDaos(): Promise<Dao[]> {
-    await this.ensureConnection();
-    if (useInMemory) {
-      return daoStorage
-        .getAll()
-        .slice()
-        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-    }
-    try {
-      const daos = await DaoModel.find().sort({ updatedAt: -1 });
-      return daos.map((dao) => dao.toObject());
-    } catch (e) {
-      console.warn("⚠️ DB error in getAllDaos, switching to in-memory fallback:", String(e));
-      useInMemory = true;
-      return daoStorage
-        .getAll()
-        .slice()
-        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-    }
+    const r = await getRepo();
+    const list = await r.findAll();
+    return list.slice().sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   }
 
   // Get last created DAO
   static async getLastCreatedDao(): Promise<Dao | null> {
-    await this.ensureConnection();
-    if (useInMemory) {
-      const list = daoStorage.getAll().slice();
-      if (list.length === 0) return null;
-      list.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-      return list[0];
-    }
-    try {
-      const doc = await DaoModel.findOne().sort({ createdAt: -1 });
-      return doc ? (doc.toObject() as Dao) : null;
-    } catch (e) {
-      console.warn("⚠️ DB error in getLastCreatedDao, using in-memory fallback:", String(e));
-      useInMemory = true;
-      const list = daoStorage.getAll().slice();
-      if (list.length === 0) return null;
-      list.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-      return list[0];
-    }
+    const r = await getRepo();
+    return r.getLastCreated();
   }
 
   // Delete last created DAO and return it
   static async deleteLastCreatedDao(): Promise<Dao | null> {
-    await this.ensureConnection();
     const last = await this.getLastCreatedDao();
     if (!last) return null;
     const ok = await this.deleteDao(last.id);
     return ok ? last : null;
   }
 
-  /**
-   * Get DAOs with optional server-side filtering, sorting and pagination.
-   * Options:
-   * - search: text search over numeroListe, objetDossier, reference
-   * - autorite: filter by autoriteContractante exact match
-   * - sort: field to sort by (default: updatedAt)
-   * - order: asc|desc
-   * - page, pageSize: pagination (1-based page)
-   */
+  // Get DAOs with filtering, sorting and pagination
   static async getDaos(opts: {
     search?: string;
     autorite?: string;
-    dateFrom?: string; // inclusive yyyy-mm-dd or ISO
-    dateTo?: string; // inclusive
+    dateFrom?: string;
+    dateTo?: string;
     sort?: string;
     order?: "asc" | "desc";
     page?: number;
     pageSize?: number;
   }): Promise<{ items: Dao[]; total: number }> {
-    await this.ensureConnection();
-    const {
-      search,
-      autorite,
-      dateFrom,
-      dateTo,
-      sort = "updatedAt",
-      order = "desc",
-      page = 1,
-      pageSize = 20,
-    } = opts || {};
-
-    if (useInMemory) {
-      let list = daoStorage.getAll().slice();
-
-      if (search && search.trim()) {
-        const q = search.toLowerCase().trim();
-        list = list.filter((d) => {
-          return (
-            (d.numeroListe && d.numeroListe.toLowerCase().includes(q)) ||
-            (d.objetDossier && d.objetDossier.toLowerCase().includes(q)) ||
-            (d.reference && d.reference.toLowerCase().includes(q)) ||
-            (d.autoriteContractante &&
-              d.autoriteContractante.toLowerCase().includes(q))
-          );
-        });
-      }
-
-      if (autorite && autorite.trim()) {
-        const a = autorite.trim();
-        list = list.filter((d) => d.autoriteContractante === a);
-      }
-
-      // Date range filter on dateDepot (inclusive)
-      if (dateFrom || dateTo) {
-        let fromTs = dateFrom ? Date.parse(dateFrom) : -Infinity;
-        let toTs = dateTo ? Date.parse(dateTo) : Infinity;
-        if (isNaN(fromTs)) fromTs = -Infinity;
-        if (isNaN(toTs)) toTs = Infinity;
-        list = list.filter((d) => {
-          const t = d.dateDepot ? Date.parse(d.dateDepot) : NaN;
-          if (isNaN(t)) return false;
-          return t >= fromTs && t <= toTs;
-        });
-      }
-
-      const direction = order === "asc" ? 1 : -1;
-      list.sort((a: any, b: any) => {
-        const av = (a as any)[sort] || "";
-        const bv = (b as any)[sort] || "";
-        if (typeof av === "string" && typeof bv === "string")
-          return direction * av.localeCompare(bv);
-        if (av < bv) return -1 * direction;
-        if (av > bv) return 1 * direction;
-        return 0;
-      });
-
-      const total = list.length;
-      const start = (Math.max(1, page) - 1) * pageSize;
-      const items = list.slice(start, start + pageSize);
-      return { items, total };
-    }
-
-    // Build mongoose query
-    const query: any = {};
-    if (search && search.trim()) {
-      const q = search.trim();
-      const regex = new RegExp(q.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "i");
-      query.$or = [
-        { numeroListe: regex },
-        { objetDossier: regex },
-        { reference: regex },
-        { autoriteContractante: regex },
-      ];
-    }
-    if (autorite && autorite.trim()) {
-      query.autoriteContractante = autorite.trim();
-    }
-
-    // Date range filter for dateDepot (inclusive) - expect ISO or yyyy-mm-dd
-    if (dateFrom || dateTo) {
-      const range: any = {};
-      if (dateFrom) {
-        const from = new Date(dateFrom);
-        if (!isNaN(from.getTime())) range.$gte = from.toISOString();
-      }
-      if (dateTo) {
-        const to = new Date(dateTo);
-        if (!isNaN(to.getTime())) {
-          // include entire day by setting to end of day
-          to.setHours(23, 59, 59, 999);
-          range.$lte = to.toISOString();
-        }
-      }
-      if (Object.keys(range).length > 0) {
-        query.dateDepot = range;
-      }
-    }
-
-    try {
-      const total = await DaoModel.countDocuments(query);
-      const sortObj: any = {};
-      sortObj[sort] = order === "asc" ? 1 : -1;
-
-      const skip = Math.max(0, (Math.max(1, page) - 1) * pageSize);
-      const docs = await DaoModel.find(query)
-        .sort(sortObj)
-        .skip(skip)
-        .limit(pageSize);
-      return { items: docs.map((d: any) => d.toObject()), total };
-    } catch (e) {
-      console.warn("⚠️ DB error in getDaos, using in-memory fallback:", String(e));
-      useInMemory = true;
-      return this.getDaos({ search, autorite, dateFrom, dateTo, sort, order, page, pageSize });
-    }
+    const r = await getRepo();
+    return r.findAndPaginate(opts);
   }
 
   // Get DAO by ID
   static async getDaoById(id: string): Promise<Dao | null> {
-    await this.ensureConnection();
-    console.log(`🔎 DaoService: Looking for DAO with ID=${id}`);
-    if (useInMemory) {
-      const result = daoStorage.findById(id) || null;
-      if (result) {
-        console.log(`✅ DaoService: Found DAO ${id} -> ${result.numeroListe}`);
-      } else {
-        console.log(`❌ DaoService: DAO ${id} not found in storage`);
-      }
-      return result;
-    }
-    try {
-      const dao = await DaoModel.findOne({ id });
-      return dao ? dao.toObject() : null;
-    } catch (e) {
-      console.warn("⚠️ DB error in getDaoById, using in-memory fallback:", String(e));
-      useInMemory = true;
-      return daoStorage.findById(id) || null;
-    }
+    const r = await getRepo();
+    return r.findById(id);
   }
 
   // Generate next DAO number (mutating: advances baseline for creations)
   static async generateNextDaoNumber(): Promise<string> {
-    await this.ensureConnection();
+    const r = await getRepo();
     const year = new Date().getFullYear();
 
-    const computeMaxSeq = (list: { numeroListe: string }[]) => {
-      const nums = list
+    const list = await r.findByNumeroYear(year);
+    const computeMaxSeq = (arr: { numeroListe: string }[]) => {
+      const nums = arr
         .map((d) => d.numeroListe.match(/DAO-(\d{4})-(\d{3})/))
         .filter((m): m is RegExpMatchArray => !!m && m[1] === String(year))
         .map((m) => parseInt(m[2], 10))
@@ -253,43 +91,20 @@ export class DaoService {
       return nums.length > 0 ? Math.max(...nums) : 0;
     };
 
-    if (useInMemory) {
-      const all = daoStorage.getAll();
-      const maxSeq = computeMaxSeq(all);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      lastIssuedSeqByYear[String(year)] = nextSeq; // advance baseline only on generate (creation)
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    }
-
-    try {
-      const existingDaos = await DaoModel.find({
-        numeroListe: { $regex: `^DAO-${year}-` },
-      });
-      const maxSeq = computeMaxSeq(existingDaos as any);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      lastIssuedSeqByYear[String(year)] = nextSeq; // advance baseline only on generate (creation)
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    } catch (e) {
-      console.warn("⚠️ DB error in generateNextDaoNumber, using in-memory fallback:", String(e));
-      useInMemory = true;
-      const all = daoStorage.getAll();
-      const maxSeq = computeMaxSeq(all);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      lastIssuedSeqByYear[String(year)] = nextSeq;
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    }
+    const maxSeq = computeMaxSeq(list as any);
+    const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
+    const nextSeq = baseline + 1;
+    lastIssuedSeqByYear[String(year)] = nextSeq;
+    return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
   }
 
-  // Peek next DAO number (non-mutating; safe for UI checks)
+  // Peek next DAO number (non-mutating)
   static async peekNextDaoNumber(): Promise<string> {
-    await this.ensureConnection();
+    const r = await getRepo();
     const year = new Date().getFullYear();
-
-    const computeMaxSeq = (list: { numeroListe: string }[]) => {
-      const nums = list
+    const list = await r.findByNumeroYear(year);
+    const computeMaxSeq = (arr: { numeroListe: string }[]) => {
+      const nums = arr
         .map((d) => d.numeroListe.match(/DAO-(\d{4})-(\d{3})/))
         .filter((m): m is RegExpMatchArray => !!m && m[1] === String(year))
         .map((m) => parseInt(m[2], 10))
@@ -297,84 +112,26 @@ export class DaoService {
       return nums.length > 0 ? Math.max(...nums) : 0;
     };
 
-    if (useInMemory) {
-      const all = daoStorage.getAll();
-      const maxSeq = computeMaxSeq(all);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    }
-
-    try {
-      const existingDaos = await DaoModel.find({
-        numeroListe: { $regex: `^DAO-${year}-` },
-      });
-      const maxSeq = computeMaxSeq(existingDaos as any);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    } catch (e) {
-      console.warn("⚠️ DB error in peekNextDaoNumber, using in-memory fallback:", String(e));
-      useInMemory = true;
-      const all = daoStorage.getAll();
-      const maxSeq = computeMaxSeq(all);
-      const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
-      const nextSeq = baseline + 1;
-      return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
-    }
+    const maxSeq = computeMaxSeq(list as any);
+    const baseline = Math.max(lastIssuedSeqByYear[String(year)] || 0, maxSeq);
+    const nextSeq = baseline + 1;
+    return `DAO-${year}-${nextSeq.toString().padStart(3, "0")}`;
   }
 
   // Create new DAO
   static async createDao(
-    daoData: Omit<Dao, "id" | "createdAt" | "updatedAt">,
+    daoData: Omit<Dao, "id" | "createdAt" | "updatedAt">
   ): Promise<Dao> {
-    await this.ensureConnection();
+    const r = await getRepo();
     const id = Date.now().toString();
     const now = new Date().toISOString();
 
-    // Always generate server-side to avoid duplicates, ignore client-provided numeroListe
+    // Always generate server-side to avoid duplicates
     let numeroListe = await this.generateNextDaoNumber();
 
-    if (useInMemory) {
-      // Ensure uniqueness in memory, retry if collision (extremely rare)
-      const existingNumbers = new Set(
-        daoStorage.getAll().map((d) => d.numeroListe),
-      );
-      while (existingNumbers.has(numeroListe)) {
-        numeroListe = await this.generateNextDaoNumber();
-      }
-      const newDao: Dao = {
-        ...daoData,
-        numeroListe,
-        id,
-        createdAt: now,
-        updatedAt: now,
-      } as Dao;
-      daoStorage.add(newDao);
-      return newDao;
-    }
-
-    // DB path: handle possible duplicate key race with small retry loop
+    // Ensure uniqueness with small retry loop for Mongo or Memory
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        const dao = new DaoModel({
-          ...daoData,
-          numeroListe,
-          id,
-          createdAt: now,
-          updatedAt: now,
-        });
-        const savedDao = await dao.save();
-        return savedDao.toObject();
-      } catch (e: any) {
-        const msg = String((e && e.message) || e);
-        if (msg.includes("E11000") || msg.toLowerCase().includes("duplicate")) {
-          // Generate a new number and retry
-          numeroListe = await this.generateNextDaoNumber();
-          continue;
-        }
-        console.warn("⚠️ DB error in createDao, using in-memory fallback:", msg);
-        useInMemory = true;
         const newDao: Dao = {
           ...daoData,
           numeroListe,
@@ -382,168 +139,66 @@ export class DaoService {
           createdAt: now,
           updatedAt: now,
         } as Dao;
-        daoStorage.add(newDao);
-        return newDao;
+        return await r.insert(newDao);
+      } catch (e: any) {
+        const msg = String((e && e.message) || e);
+        if (msg.includes("E11000") || msg.toLowerCase().includes("duplicate")) {
+          numeroListe = await this.generateNextDaoNumber();
+          continue;
+        }
+        throw e;
       }
     }
-    // Final attempt failed due to persistent duplicates or DB errors — fallback
-    const fallbackDao: Dao = {
+
+    const finalDao: Dao = {
       ...daoData,
       numeroListe,
       id,
       createdAt: now,
       updatedAt: now,
     } as Dao;
-    daoStorage.add(fallbackDao);
-    useInMemory = true;
-    return fallbackDao;
+    return r.insert(finalDao);
   }
 
   // Update DAO
-  static async updateDao(
-    id: string,
-    updates: Partial<Dao>,
-  ): Promise<Dao | null> {
-    await this.ensureConnection();
-    if (useInMemory) {
-      const index = daoStorage.findIndexById(id);
-      if (index === -1) return null;
-      const existing = daoStorage.findById(id)!;
-      const updated: Dao = {
-        ...existing,
-        ...updates,
-        updatedAt: new Date().toISOString(),
-      } as Dao;
-      daoStorage.updateAtIndex(index, updated);
-      return updated;
-    }
-    try {
-      const updatedDao = await DaoModel.findOneAndUpdate(
-        { id },
-        { ...updates, updatedAt: new Date().toISOString() },
-        { new: true },
-      );
-      return updatedDao ? updatedDao.toObject() : null;
-    } catch (e) {
-      console.warn("⚠️ DB error in updateDao, using in-memory fallback:", String(e));
-      useInMemory = true;
-      const index = daoStorage.findIndexById(id);
-      if (index === -1) return null;
-      const existing = daoStorage.findById(id)!;
-      const updated: Dao = {
-        ...existing,
-        ...updates,
-        updatedAt: new Date().toISOString(),
-      } as Dao;
-      daoStorage.updateAtIndex(index, updated);
-      return updated;
-    }
+  static async updateDao(id: string, updates: Partial<Dao>): Promise<Dao | null> {
+    const r = await getRepo();
+    return r.update(id, { ...updates, updatedAt: new Date().toISOString() });
   }
 
   // Delete DAO
   static async deleteDao(id: string): Promise<boolean> {
-    await this.ensureConnection();
-    if (useInMemory) {
-      // Find DAO to adjust sequence if needed
-      const existing = daoStorage.findById(id);
-      const ok = daoStorage.deleteById(id);
-      if (ok && existing?.numeroListe) {
-        const m = existing.numeroListe.match(/DAO-(\d{4})-(\d{3})/);
-        if (m) {
-          const year = m[1];
-          const maxSeq = daoStorage
-            .getAll()
-            .filter((d) => d.numeroListe.startsWith(`DAO-${year}-`))
-            .map((d) =>
-              parseInt(
-                d.numeroListe.match(/DAO-\d{4}-(\d{3})/)?.[1] || "0",
-                10,
-              ),
-            )
-            .filter((n) => !isNaN(n))
-            .reduce((a, b) => Math.max(a, b), 0);
-          lastIssuedSeqByYear[year] = maxSeq;
-        }
+    const r = await getRepo();
+    const existing = await r.findById(id);
+    const ok = await r.deleteById(id);
+    if (ok && existing?.numeroListe) {
+      const m = existing.numeroListe.match(/DAO-(\d{4})-(\d{3})/);
+      if (m) {
+        const year = m[1];
+        const remaining = await r.findByNumeroYear(year);
+        const nums = remaining
+          .map((d) => d.numeroListe.match(/DAO-\d{4}-(\d{3})/))
+          .map((mm) => parseInt((mm ? mm[1] : "0") as string, 10))
+          .filter((n) => !isNaN(n));
+        lastIssuedSeqByYear[year] = nums.length ? Math.max(...nums) : 0;
       }
-      return ok;
     }
-    try {
-      const doc = await DaoModel.findOne({ id });
-      const result = await DaoModel.deleteOne({ id });
-      if (result.deletedCount && doc?.numeroListe) {
-        const m = doc.numeroListe.match(/DAO-(\d{4})-(\d{3})/);
-        if (m) {
-          const year = m[1];
-          const remaining = await DaoModel.find({
-            numeroListe: { $regex: `^DAO-${year}-` },
-          });
-          const nums = remaining
-            .map((d: any) => {
-              const m2 = d.numeroListe.match(/DAO-\d{4}-(\d{3})/);
-              return parseInt((m2 ? m2[1] : "0") as string, 10);
-            })
-            .filter((n: number) => !isNaN(n));
-          lastIssuedSeqByYear[year] = nums.length ? Math.max(...nums) : 0;
-        }
-      }
-      return result.deletedCount > 0;
-    } catch (e) {
-      console.warn("⚠️ DB error in deleteDao, using in-memory fallback:", String(e));
-      useInMemory = true;
-      const existing = daoStorage.findById(id);
-      const ok = daoStorage.deleteById(id);
-      if (ok && existing?.numeroListe) {
-        const m = existing.numeroListe.match(/DAO-(\d{4})-(\d{3})/);
-        if (m) {
-          const year = m[1];
-          const maxSeq = daoStorage
-            .getAll()
-            .filter((d) => d.numeroListe.startsWith(`DAO-${year}-`))
-            .map((d) => {
-              const mm = d.numeroListe.match(/DAO-\d{4}-(\d{3})/);
-              return parseInt((mm ? mm[1] : "0") as string, 10);
-            })
-            .filter((n) => !isNaN(n))
-            .reduce((a, b) => Math.max(a, b), 0);
-          lastIssuedSeqByYear[year] = maxSeq;
-        }
-      }
-      return ok;
-    }
+    return ok;
   }
 
-  // Initialize with sample data if empty
+  // Initialize with sample data if empty (no-op for memory since seeding is handled elsewhere)
   static async initializeSampleData(sampleDaos: Dao[]): Promise<void> {
-    await this.ensureConnection();
-    if (useInMemory) {
-      // already seeded via daoStorage
-      return;
-    }
-    const count = await DaoModel.countDocuments();
-    if (count === 0) {
-      console.log("🌱 Initializing database with sample data...");
-      await DaoModel.insertMany(sampleDaos);
-      console.log("✅ Sample data initialized");
+    const r = await getRepo();
+    const c = await r.count();
+    if (c === 0 && sampleDaos.length) {
+      await r.insertMany(sampleDaos);
     }
   }
 
   // Clear all DAOs (DB or in-memory)
   static async clearAll(): Promise<void> {
-    await this.ensureConnection();
-    // Reset sequence baselines for all years to avoid starting at a higher number after purge
-    for (const k of Object.keys(lastIssuedSeqByYear))
-      delete lastIssuedSeqByYear[k];
-
-    if (useInMemory) {
-      daoStorage.clearAll(false);
-      return;
-    }
-    try {
-      await DaoModel.deleteMany({});
-      console.log("🧹 All DAOs removed from database");
-    } catch (e) {
-      console.error("❌ Failed to clear DAOs from database:", e);
-      throw e;
-    }
+    const r = await getRepo();
+    for (const k of Object.keys(lastIssuedSeqByYear)) delete lastIssuedSeqByYear[k];
+    await r.deleteAll();
   }
 }

--- a/backend-express/services/daoService.ts
+++ b/backend-express/services/daoService.ts
@@ -26,7 +26,10 @@ async function getRepo(): Promise<DaoRepository> {
     repo = new MongoDaoRepository();
     return repo;
   } catch (e) {
-    console.warn("⚠️ USE_MONGO=true but MongoDB not available, falling back to in-memory repository:", String(e));
+    console.warn(
+      "⚠️ USE_MONGO=true but MongoDB not available, falling back to in-memory repository:",
+      String(e),
+    );
     repo = new MemoryDaoRepository();
     return repo;
   }
@@ -119,7 +122,7 @@ export class DaoService {
 
   // Create new DAO
   static async createDao(
-    daoData: Omit<Dao, "id" | "createdAt" | "updatedAt">
+    daoData: Omit<Dao, "id" | "createdAt" | "updatedAt">,
   ): Promise<Dao> {
     const r = await getRepo();
     const id = Date.now().toString();
@@ -160,7 +163,10 @@ export class DaoService {
   }
 
   // Update DAO
-  static async updateDao(id: string, updates: Partial<Dao>): Promise<Dao | null> {
+  static async updateDao(
+    id: string,
+    updates: Partial<Dao>,
+  ): Promise<Dao | null> {
     const r = await getRepo();
     return r.update(id, { ...updates, updatedAt: new Date().toISOString() });
   }
@@ -197,7 +203,8 @@ export class DaoService {
   // Clear all DAOs (DB or in-memory)
   static async clearAll(): Promise<void> {
     const r = await getRepo();
-    for (const k of Object.keys(lastIssuedSeqByYear)) delete lastIssuedSeqByYear[k];
+    for (const k of Object.keys(lastIssuedSeqByYear))
+      delete lastIssuedSeqByYear[k];
     await r.deleteAll();
   }
 }

--- a/backend-express/services/daoService.ts
+++ b/backend-express/services/daoService.ts
@@ -4,8 +4,6 @@ import { MemoryDaoRepository } from "../repositories/memoryDaoRepository";
 import { MongoDaoRepository } from "../repositories/mongoDaoRepository";
 import type { DaoRepository } from "../repositories/daoRepository";
 
-const WANT_MONGO = (process.env.USE_MONGO || "").toLowerCase() === "true";
-
 // Monotonic per-year sequence tracker to avoid reusing numbers after deletions
 const lastIssuedSeqByYear: Record<string, number> = {};
 
@@ -17,6 +15,7 @@ async function getRepo(): Promise<DaoRepository> {
   if (attempted) return repo || new MemoryDaoRepository();
   attempted = true;
 
+  const WANT_MONGO = (process.env.USE_MONGO || "").toLowerCase() === "true";
   if (!WANT_MONGO) {
     repo = new MemoryDaoRepository();
     return repo;

--- a/backend-express/tests/daoRepository.test.ts
+++ b/backend-express/tests/daoRepository.test.ts
@@ -27,7 +27,9 @@ describe("MemoryDaoRepository", () => {
   });
 
   it("creates, reads, updates and deletes DAOs", async () => {
-    const created = await repo.insert(sampleDao({ numeroListe: "DAO-2099-010" }));
+    const created = await repo.insert(
+      sampleDao({ numeroListe: "DAO-2099-010" }),
+    );
     expect(created.id).toBeTruthy();
 
     const fetched = await repo.findById(created.id);
@@ -47,11 +49,21 @@ describe("MemoryDaoRepository", () => {
 
   it("paginates and filters", async () => {
     await repo.deleteAll();
-    await repo.insert(sampleDao({ numeroListe: "DAO-2099-001", autoriteContractante: "A" }));
-    await repo.insert(sampleDao({ numeroListe: "DAO-2099-002", autoriteContractante: "B" }));
-    await repo.insert(sampleDao({ numeroListe: "DAO-2099-003", autoriteContractante: "A" }));
+    await repo.insert(
+      sampleDao({ numeroListe: "DAO-2099-001", autoriteContractante: "A" }),
+    );
+    await repo.insert(
+      sampleDao({ numeroListe: "DAO-2099-002", autoriteContractante: "B" }),
+    );
+    await repo.insert(
+      sampleDao({ numeroListe: "DAO-2099-003", autoriteContractante: "A" }),
+    );
 
-    const { items, total } = await repo.findAndPaginate({ autorite: "A", page: 1, pageSize: 10 });
+    const { items, total } = await repo.findAndPaginate({
+      autorite: "A",
+      page: 1,
+      pageSize: 10,
+    });
     expect(total).toBe(2);
     expect(items.every((d) => d.autoriteContractante === "A")).toBe(true);
   });
@@ -82,7 +94,9 @@ describe("DaoService with USE_MONGO toggle", () => {
     process.env.USE_MONGO = "true";
     vi.resetModules();
     vi.mock("../config/database", () => ({
-      connectToDatabase: vi.fn(async () => { throw new Error("no mongo"); }),
+      connectToDatabase: vi.fn(async () => {
+        throw new Error("no mongo");
+      }),
     }));
 
     const { DaoService } = await import("../services/daoService");

--- a/backend-express/tests/daoRepository.test.ts
+++ b/backend-express/tests/daoRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Dao } from "@shared/dao";
+import { MemoryDaoRepository } from "../repositories/memoryDaoRepository";
+
+function sampleDao(overrides: Partial<Dao> = {}): Dao {
+  const now = new Date().toISOString();
+  return {
+    id: String(Date.now() + Math.random()),
+    numeroListe: "DAO-2099-001",
+    objetDossier: "Test",
+    reference: "REF-1",
+    autoriteContractante: "Test Org",
+    dateDepot: now,
+    equipe: [],
+    tasks: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+describe("MemoryDaoRepository", () => {
+  let repo: MemoryDaoRepository;
+
+  beforeEach(() => {
+    repo = new MemoryDaoRepository();
+  });
+
+  it("creates, reads, updates and deletes DAOs", async () => {
+    const created = await repo.insert(sampleDao({ numeroListe: "DAO-2099-010" }));
+    expect(created.id).toBeTruthy();
+
+    const fetched = await repo.findById(created.id);
+    expect(fetched?.numeroListe).toBe("DAO-2099-010");
+
+    const updated = await repo.update(created.id, { objetDossier: "Updated" });
+    expect(updated?.objetDossier).toBe("Updated");
+
+    const all = await repo.findAll();
+    expect(all.length).toBeGreaterThan(0);
+
+    const ok = await repo.deleteById(created.id);
+    expect(ok).toBe(true);
+    const after = await repo.findById(created.id);
+    expect(after).toBeNull();
+  });
+
+  it("paginates and filters", async () => {
+    await repo.deleteAll();
+    await repo.insert(sampleDao({ numeroListe: "DAO-2099-001", autoriteContractante: "A" }));
+    await repo.insert(sampleDao({ numeroListe: "DAO-2099-002", autoriteContractante: "B" }));
+    await repo.insert(sampleDao({ numeroListe: "DAO-2099-003", autoriteContractante: "A" }));
+
+    const { items, total } = await repo.findAndPaginate({ autorite: "A", page: 1, pageSize: 10 });
+    expect(total).toBe(2);
+    expect(items.every((d) => d.autoriteContractante === "A")).toBe(true);
+  });
+});
+
+describe("DaoService with USE_MONGO toggle", () => {
+  it("uses in-memory when USE_MONGO=false", async () => {
+    process.env.USE_MONGO = "false";
+    const { DaoService } = await import("../services/daoService");
+
+    const before = await DaoService.getAllDaos();
+    const created = await DaoService.createDao({
+      numeroListe: "SHOULD_BE_OVERRIDDEN",
+      objetDossier: "OBJ",
+      reference: "REF",
+      autoriteContractante: "X",
+      dateDepot: new Date().toISOString(),
+      equipe: [],
+      tasks: [],
+    } as any);
+    expect(created.numeroListe.startsWith("DAO-")).toBe(true);
+
+    const after = await DaoService.getAllDaos();
+    expect(after.length).toBeGreaterThanOrEqual(before.length + 1);
+  });
+
+  it("falls back to memory when USE_MONGO=true but connection fails", async () => {
+    process.env.USE_MONGO = "true";
+    vi.resetModules();
+    vi.mock("../config/database", () => ({
+      connectToDatabase: vi.fn(async () => { throw new Error("no mongo"); }),
+    }));
+
+    const { DaoService } = await import("../services/daoService");
+
+    const created = await DaoService.createDao({
+      numeroListe: "SHOULD_BE_OVERRIDDEN",
+      objetDossier: "OBJ",
+      reference: "REF",
+      autoriteContractante: "Y",
+      dateDepot: new Date().toISOString(),
+      equipe: [],
+      tasks: [],
+    } as any);
+    expect(created.id).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Purpose

The user requested a complete Node.js + Express backend structure that supports both fallback (in-memory) and real database (MongoDB) modes. The goal was to implement a repository pattern where all features work identically in both modes, controlled by a `USE_MONGO` environment variable, ensuring the frontend communication remains consistent regardless of storage mode.

## Code changes

- **Environment configuration**: Updated `.env.example` to include `USE_MONGO` toggle and simplified configuration structure
- **Repository pattern implementation**: 
  - Created `DaoRepository` interface defining common operations (CRUD, pagination, search)
  - Implemented `MemoryDaoRepository` for in-memory storage operations
  - Implemented `MongoDaoRepository` for MongoDB operations via Mongoose
- **Model improvements**: Fixed Mongoose model compilation to prevent `OverwriteModelError` in tests
- **Service layer refactoring**: Updated `DaoService` to use repository abstraction instead of direct storage access
- **Test coverage**: Added comprehensive tests for repository pattern and storage mode switching
- **Error handling**: Improved fallback mechanism when MongoDB connection fails

The implementation ensures seamless switching between storage modes while maintaining identical API behavior and responses.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1497e694257f40549338909b01bd04d1/vibe-field)

👀 [Preview Link](https://1497e694257f40549338909b01bd04d1-vibe-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1497e694257f40549338909b01bd04d1</projectId>-->
<!--<branchName>vibe-field</branchName>-->