### PR TITLE
Add DAO validation and change history tracking

### DIFF
--- a/src/backend-express/routes/dao-simple.ts
+++ b/src/backend-express/routes/dao-simple.ts
@@ -448,8 +448,11 @@ router.put(
 
           // Détection de changement de chef d'équipe
           const oldLeader = before.equipe.find((m) => m.role === "chef_equipe");
-          const newLeader = updated.equipe.find((m) => m.role === "chef_equipe");
-          const leaderChanged = (oldLeader?.id || null) !== (newLeader?.id || null);
+          const newLeader = updated.equipe.find(
+            (m) => m.role === "chef_equipe",
+          );
+          const leaderChanged =
+            (oldLeader?.id || null) !== (newLeader?.id || null);
 
           if (leaderChanged) {
             try {
@@ -1010,7 +1013,8 @@ router.post(
 // Historique: GET /api/dao/history?date=YYYY-MM-DD&dateFrom=..&dateTo=..
 router.get("/history", authenticate, async (req, res) => {
   try {
-    const date = typeof req.query.date === "string" ? req.query.date : undefined;
+    const date =
+      typeof req.query.date === "string" ? req.query.date : undefined;
     const dateFrom =
       typeof req.query.dateFrom === "string" ? req.query.dateFrom : undefined;
     const dateTo =

--- a/src/backend-express/routes/dao-simple.ts
+++ b/src/backend-express/routes/dao-simple.ts
@@ -27,8 +27,11 @@ import {
   tplDaoUpdated,
   tplDaoDeleted,
   tplTaskNotification,
+  tplDaoAggregatedUpdate,
+  tplLeaderChanged,
 } from "../services/notificationTemplates";
 import { daoStorage } from "../data/daoStorage";
+import { DaoChangeLogService } from "../services/daoChangeLogService";
 
 const router = express.Router();
 

--- a/src/backend-express/routes/dao-simple.ts
+++ b/src/backend-express/routes/dao-simple.ts
@@ -76,7 +76,7 @@ const taskUpdateSchema = z.object({
 });
 
 /**
- * Nettoie une cha��ne utilisateur:
+ * Nettoie une chaîne utilisateur:
  * - retire balises <script>/<style>
  * - supprime toutes balises HTML restantes
  * - trim
@@ -884,7 +884,13 @@ router.put(
 
       const updated = await DaoService.updateDao(id, { tasks: dao.tasks });
 
-      // Broadcast task notification to all users
+      // Enregistrer pour agrégation (validation)
+      try {
+        const fullDao = await DaoService.getDaoById(id);
+        if (fullDao) DaoChangeLogService.recordTaskChange(fullDao, task);
+      } catch (_) {}
+
+      // Broadcast task notification à tous les utilisateurs
       try {
         const prevSet = new Set(previous.assignedTo || []);
         const currSet = new Set(task.assignedTo || []);

--- a/src/backend-express/services/daoChangeLogService.ts
+++ b/src/backend-express/services/daoChangeLogService.ts
@@ -1,0 +1,158 @@
+/**
+Rôle: Service métier — suivi des changements DAO (agrégation + historique)
+Domaine: Backend/Services
+Exports: DaoChangeLogService
+Liens: utilisé par routes DAO/Tâches/Commentaires et endpoint de validation
+*/
+import type { Dao, DaoTask } from "@shared/dao";
+import { logger } from "../utils/logger";
+import type { DaoAggregatedSummary, DaoHistoryEntry } from "@shared/api";
+
+interface PendingTaskChange {
+  taskId: number;
+  isApplicable?: boolean;
+  progress?: number | null;
+  comment?: string;
+}
+
+interface PendingByDao {
+  daoId: string;
+  numeroListe: string;
+  tasks: Map<number, PendingTaskChange>; // taskId -> latest state snapshot for fields of interest
+  lastTouchedAt: string; // ISO
+}
+
+class InMemoryDaoChangeLogService {
+  private pending: Map<string, PendingByDao> = new Map(); // daoId -> pending
+  private historyByDay: Map<string, DaoHistoryEntry[]> = new Map(); // YYYY-MM-DD -> entries
+
+  private dayKey(d = new Date()): string {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const dd = String(d.getDate()).padStart(2, "0");
+    return `${y}-${m}-${dd}`;
+    }
+
+  recordTaskChange(dao: Dao, task: DaoTask): void {
+    const p = this.ensurePending(dao);
+    const rec: PendingTaskChange = {
+      taskId: task.id,
+      isApplicable: task.isApplicable,
+      progress: task.isApplicable ? task.progress ?? 0 : null,
+      comment: task.comment,
+    };
+    p.tasks.set(task.id, rec);
+    p.lastTouchedAt = new Date().toISOString();
+  }
+
+  recordLeaderChange(dao: Dao, oldLeaderName: string | null, newLeaderName: string | null): void {
+    // Pour l'agrégation « Mise à jour DAO », on n'ajoute pas de ligne spéciale pour le chef
+    // car une notification dédiée est envoyée immédiatement. On marque tout de même l'activité.
+    const p = this.ensurePending(dao);
+    p.lastTouchedAt = new Date().toISOString();
+    logger.info(`Leader change enregistré pour ${dao.numeroListe}: ${oldLeaderName} -> ${newLeaderName}`, "DAO_CHANGELOG");
+  }
+
+  clearPending(daoId: string): void {
+    this.pending.delete(daoId);
+  }
+
+  private ensurePending(dao: Dao): PendingByDao {
+    let p = this.pending.get(dao.id);
+    if (!p) {
+      p = {
+        daoId: dao.id,
+        numeroListe: dao.numeroListe,
+        tasks: new Map<number, PendingTaskChange>(),
+        lastTouchedAt: new Date().toISOString(),
+      };
+      this.pending.set(dao.id, p);
+    }
+    return p;
+  }
+
+  buildAggregatedSummary(dao: Dao, maxLines = 6): DaoAggregatedSummary | null {
+    const p = this.pending.get(dao.id);
+    const createdAt = new Date().toISOString();
+    if (!p || p.tasks.size === 0) {
+      return {
+        daoId: dao.id,
+        numeroListe: dao.numeroListe,
+        title: "Mise à jour DAO",
+        message: `Numéro de liste : ${dao.numeroListe}`,
+        lines: [`Numéro de liste : ${dao.numeroListe}`],
+        createdAt,
+      };
+    }
+
+    // Ordonner par taskId pour une sortie stable
+    const entries = Array.from(p.tasks.values()).sort((a, b) => a.taskId - b.taskId);
+    const lines: string[] = [];
+    lines.push(`Numéro de liste : ${dao.numeroListe}`);
+    let count = 0;
+    for (const item of entries) {
+      if (count >= maxLines) break;
+      const parts: string[] = [];
+      parts.push(`Tâche ${item.taskId} :`);
+      if (typeof item.isApplicable === "boolean")
+        parts.push(`Applicabilité : ${item.isApplicable ? "Oui" : "Non"}`);
+      if (item.isApplicable && typeof item.progress === "number")
+        parts.push(`Progression : ${item.progress}%`);
+      if (item.comment && item.comment.trim())
+        parts.push(`Commentaire: "${item.comment.trim()}"`);
+      lines.push(parts.join(" "));
+      count++;
+    }
+
+    if (entries.length > maxLines) {
+      lines.push("(...)");
+    }
+
+    const message = lines.join("\n");
+    return {
+      daoId: dao.id,
+      numeroListe: dao.numeroListe,
+      title: "Mise à jour DAO",
+      message,
+      lines,
+      createdAt,
+    };
+  }
+
+  finalizeAndStoreHistory(summary: DaoAggregatedSummary): DaoHistoryEntry {
+    const entry: DaoHistoryEntry = {
+      id: `hist_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      daoId: summary.daoId,
+      numeroListe: summary.numeroListe,
+      createdAt: summary.createdAt,
+      summary: summary.title,
+      lines: summary.lines,
+    };
+    const key = this.dayKey(new Date(summary.createdAt));
+    const arr = this.historyByDay.get(key) || [];
+    arr.unshift(entry);
+    this.historyByDay.set(key, arr.slice(0, 1000));
+    return entry;
+  }
+
+  listHistory(opts?: { date?: string; dateFrom?: string; dateTo?: string }): DaoHistoryEntry[] {
+    // Si date fournie, retourner ce jour
+    if (opts?.date) {
+      return (this.historyByDay.get(opts.date) || []).slice();
+    }
+    // Sinon, plage
+    const from = opts?.dateFrom ? new Date(opts.dateFrom) : null;
+    const to = opts?.dateTo ? new Date(opts.dateTo) : null;
+    const out: DaoHistoryEntry[] = [];
+    for (const [day, entries] of this.historyByDay) {
+      const d = new Date(day + "T00:00:00.000Z");
+      if (from && d < from) continue;
+      if (to && d > to) continue;
+      out.push(...entries);
+    }
+    // Tri décroissant par date de création des entrées
+    return out.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  }
+}
+
+export const DaoChangeLogService = new InMemoryDaoChangeLogService();

--- a/src/backend-express/services/daoChangeLogService.ts
+++ b/src/backend-express/services/daoChangeLogService.ts
@@ -31,26 +31,33 @@ class InMemoryDaoChangeLogService {
     const m = String(d.getMonth() + 1).padStart(2, "0");
     const dd = String(d.getDate()).padStart(2, "0");
     return `${y}-${m}-${dd}`;
-    }
+  }
 
   recordTaskChange(dao: Dao, task: DaoTask): void {
     const p = this.ensurePending(dao);
     const rec: PendingTaskChange = {
       taskId: task.id,
       isApplicable: task.isApplicable,
-      progress: task.isApplicable ? task.progress ?? 0 : null,
+      progress: task.isApplicable ? (task.progress ?? 0) : null,
       comment: task.comment,
     };
     p.tasks.set(task.id, rec);
     p.lastTouchedAt = new Date().toISOString();
   }
 
-  recordLeaderChange(dao: Dao, oldLeaderName: string | null, newLeaderName: string | null): void {
+  recordLeaderChange(
+    dao: Dao,
+    oldLeaderName: string | null,
+    newLeaderName: string | null,
+  ): void {
     // Pour l'agrégation « Mise à jour DAO », on n'ajoute pas de ligne spéciale pour le chef
     // car une notification dédiée est envoyée immédiatement. On marque tout de même l'activité.
     const p = this.ensurePending(dao);
     p.lastTouchedAt = new Date().toISOString();
-    logger.info(`Leader change enregistré pour ${dao.numeroListe}: ${oldLeaderName} -> ${newLeaderName}`, "DAO_CHANGELOG");
+    logger.info(
+      `Leader change enregistré pour ${dao.numeroListe}: ${oldLeaderName} -> ${newLeaderName}`,
+      "DAO_CHANGELOG",
+    );
   }
 
   clearPending(daoId: string): void {
@@ -86,7 +93,9 @@ class InMemoryDaoChangeLogService {
     }
 
     // Ordonner par taskId pour une sortie stable
-    const entries = Array.from(p.tasks.values()).sort((a, b) => a.taskId - b.taskId);
+    const entries = Array.from(p.tasks.values()).sort(
+      (a, b) => a.taskId - b.taskId,
+    );
     const lines: string[] = [];
     lines.push(`Numéro de liste : ${dao.numeroListe}`);
     let count = 0;
@@ -135,7 +144,11 @@ class InMemoryDaoChangeLogService {
     return entry;
   }
 
-  listHistory(opts?: { date?: string; dateFrom?: string; dateTo?: string }): DaoHistoryEntry[] {
+  listHistory(opts?: {
+    date?: string;
+    dateFrom?: string;
+    dateTo?: string;
+  }): DaoHistoryEntry[] {
     // Si date fournie, retourner ce jour
     if (opts?.date) {
       return (this.historyByDay.get(opts.date) || []).slice();

--- a/src/backend-express/services/notificationTemplates.ts
+++ b/src/backend-express/services/notificationTemplates.ts
@@ -145,6 +145,40 @@ export function tplDaoDeleted(
   };
 }
 
+// Agrégation (validation)
+export function tplDaoAggregatedUpdate(params: {
+  dao: Dao;
+  lines: string[];
+}): Pick<ServerNotification, "type" | "title" | "message" | "data"> {
+  const { dao, lines } = params;
+  const msg = lines.join("\n");
+  return {
+    type: "dao_updated",
+    title: "Mise à jour DAO",
+    message: msg,
+    data: { event: "dao_aggregated_update", daoId: dao.id },
+  };
+}
+
+export function tplLeaderChanged(params: {
+  dao: Dao;
+  oldLeader?: string | null;
+  newLeader?: string | null;
+}): Pick<ServerNotification, "type" | "title" | "message" | "data"> {
+  const { dao, oldLeader, newLeader } = params;
+  const lines = [
+    `Numéro de liste : ${dao.numeroListe}`,
+    `Ancien Chef d'équipe : ${oldLeader || "Non défini"}`,
+    `Nouveau Chef d'équipe : ${newLeader || "Non défini"}`,
+  ];
+  return {
+    type: "role_update",
+    title: "Changement de chef d'équipe",
+    message: lines.join("\n"),
+    data: { event: "leader_changed", daoId: dao.id },
+  };
+}
+
 // ===== TASK templates =====
 export function tplTaskNotification(params: {
   dao: Dao;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,7 +1,7 @@
 /**
 Rôle: Types & contrats partagés — src/shared/api.ts
 Domaine: Shared
-Exports: DemoResponse
+Exports: DemoResponse, DaoHistoryEntry, DaoAggregatedSummary
 Liens: importé par frontend et backend
 */
 /**
@@ -15,4 +15,28 @@ Liens: importé par frontend et backend
  */
 export interface DemoResponse {
   message: string;
+}
+
+/**
+ * Entrée d'historique des modifications de DAO (journal quotidien)
+ */
+export interface DaoHistoryEntry {
+  id: string;
+  daoId: string;
+  numeroListe: string;
+  createdAt: string; // ISO
+  summary: string; // Titre + courte synthèse
+  lines: string[]; // Lignes détaillées (affichage)
+}
+
+/**
+ * Résumé agrégé renvoyé lors d'une validation côté serveur
+ */
+export interface DaoAggregatedSummary {
+  daoId: string;
+  numeroListe: string;
+  title: string; // "Mise à jour DAO"
+  message: string; // corps prêt pour notification/email
+  lines: string[]; // lignes utilisées pour le message
+  createdAt: string; // ISO
 }


### PR DESCRIPTION
## Purpose

This PR implements a comprehensive DAO validation and change tracking system based on user requirements. The main goals are:

- Replace individual modification notifications with aggregated "Mise à jour DAO" notifications
- Add a centralized validation button that triggers batch notifications and emails to all platform users
- Implement leader change detection with dedicated notifications
- Create a DAO history page accessible to all users with date filtering capabilities
- Ensure notifications redirect users to the specific DAO when clicked

## Code changes

### Backend Services
- **New `DaoChangeLogService`**: In-memory service for tracking pending DAO changes and managing history
  - Records task modifications (applicability, progress, comments) for later aggregation
  - Detects and logs leader changes separately
  - Builds aggregated summaries with configurable line limits and "(...)" truncation
  - Maintains daily history entries with date-based filtering

### API Endpoints
- **POST `/api/dao/:id/validate`**: New validation endpoint that:
  - Aggregates all pending changes for a DAO
  - Sends single "Mise à jour DAO" notification to all users
  - Stores changes in history and clears pending state
- **GET `/api/dao/history`**: New history endpoint with date range filtering (`date`, `dateFrom`, `dateTo`)

### Notification Templates
- **`tplDaoAggregatedUpdate`**: Template for batch DAO updates with format "Numéro de liste: X, Tâche 1: Applicabilité: Oui, Progression: 50%, Commentaire: 'Bien fait'..."
- **`tplLeaderChanged`**: Dedicated template for leader changes with old/new leader names

### Enhanced DAO Routes
- Modified team member update logic to detect leader changes and send immediate notifications
- Integrated change logging for task updates while maintaining existing individual notifications
- Fixed team member removal logic (corrected ID mapping bug)

### Shared Types
- Added `DaoHistoryEntry` and `DaoAggregatedSummary` interfaces for type safety across frontend/backendTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1558492975854a42ae75a67bbc235d4f/orbit-world)

👀 [Preview Link](https://1558492975854a42ae75a67bbc235d4f-orbit-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1558492975854a42ae75a67bbc235d4f</projectId>-->
<!--<branchName>orbit-world</branchName>-->